### PR TITLE
chore: [박태준] 기존 목업 데이터를 실제 사용자 인증 시스템과 연동한다.

### DIFF
--- a/src/main/java/com/wowraid/jobspoon/studyApplication/controller/StudyApplicationController.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/controller/StudyApplicationController.java
@@ -1,0 +1,56 @@
+package com.wowraid.jobspoon.studyApplication.controller;
+
+import com.wowraid.jobspoon.redis_cache.RedisCacheService;
+import com.wowraid.jobspoon.studyApplication.controller.request_form.CreateStudyApplicationRequestForm;
+import com.wowraid.jobspoon.studyApplication.controller.response_form.CreateStudyApplicationResponseForm;
+import com.wowraid.jobspoon.studyApplication.service.StudyApplicationService;
+import com.wowraid.jobspoon.studyApplication.service.response.CreateStudyApplicationResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study-applications")
+public class StudyApplicationController {
+
+    private final StudyApplicationService studyApplicationService;
+    private final RedisCacheService redisCacheService;
+
+    @PostMapping
+    public ResponseEntity<CreateStudyApplicationResponseForm> applyToStudy(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody CreateStudyApplicationRequestForm requestForm
+    ) {
+        log.info("스터디 지원 요청 시작. studyRoomId={}, message='{}'", requestForm.getStudyRoomId(), requestForm.getMessage());
+
+        // 'Bearer ' 형식 검증 (유지)
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new IllegalArgumentException("유효하지 않은 토큰 형식입니다.");
+        }
+        String token = authorizationHeader.substring(7);
+
+        // Redis 조회 및 null 체크 (유지)
+        Long applicantId = redisCacheService.getValueByKey(token, Long.class);
+        if (applicantId == null) {
+            log.warn("유효하지 않은 토큰으로 인한 접근 거부. token={}", token);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        CreateStudyApplicationResponse serviceResponse =
+                studyApplicationService.applyToStudy(requestForm.toServiceRequest(applicantId));
+
+        CreateStudyApplicationResponseForm responseForm = CreateStudyApplicationResponseForm.from(serviceResponse);
+
+        log.info("스터디 지원 성공. applicationId={}", responseForm.getApplicationId());
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .location(URI.create("/api/study-applications/" + responseForm.getApplicationId()))
+                .body(responseForm);
+    }
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/controller/request_form/CreateStudyApplicationRequestForm.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/controller/request_form/CreateStudyApplicationRequestForm.java
@@ -1,0 +1,16 @@
+package com.wowraid.jobspoon.studyApplication.controller.request_form;
+
+import com.wowraid.jobspoon.studyApplication.service.request.CreateStudyApplicationRequest;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateStudyApplicationRequestForm {
+    private final Long studyRoomId;
+    private final String message;
+
+    public CreateStudyApplicationRequest toServiceRequest(Long applicantId) {
+        return new CreateStudyApplicationRequest(studyRoomId, applicantId, message);
+    }
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/controller/response_form/CreateStudyApplicationResponseForm.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/controller/response_form/CreateStudyApplicationResponseForm.java
@@ -1,0 +1,24 @@
+package com.wowraid.jobspoon.studyApplication.controller.response_form;
+
+import com.wowraid.jobspoon.studyApplication.entity.ApplicationStatus;
+import com.wowraid.jobspoon.studyApplication.service.response.CreateStudyApplicationResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateStudyApplicationResponseForm {
+    private final Long applicationId;
+    private final ApplicationStatus status;
+    private final LocalDateTime appliedAt;
+
+    public static CreateStudyApplicationResponseForm from(CreateStudyApplicationResponse response) {
+        return new CreateStudyApplicationResponseForm(
+                response.getApplicationId(),
+                response.getStatus(),
+                response.getAppliedAt()
+        );
+    }
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/entity/ApplicationStatus.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/entity/ApplicationStatus.java
@@ -1,0 +1,15 @@
+package com.wowraid.jobspoon.studyApplication.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApplicationStatus {
+    PENDING("대기중"),
+    APPROVED("승인됨"),
+    REJECTED("거절됨"),
+    CANCELED("지원취소");
+
+    private final String description;
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/entity/StudyApplication.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/entity/StudyApplication.java
@@ -1,0 +1,61 @@
+package com.wowraid.jobspoon.studyApplication.entity;
+
+import com.wowraid.jobspoon.accountProfile.entity.AccountProfile;
+import com.wowraid.jobspoon.studyroom.entity.StudyRoom;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.aspectj.bridge.IMessage;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "study_application")          // 테이블명
+public class StudyApplication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 하나의 스터디는 여러 개의 지원을 받음 다대일 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_room_id", nullable = false)
+    private StudyRoom studyRoom;
+
+    // 하나의 계정은 여러 스터디에 지원할 수 있음 다대일 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "accountprofile_id", nullable = false)
+    private AccountProfile applicant;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ApplicationStatus status;
+
+    @Column(name = "applied_at", nullable = false)
+    private LocalDateTime appliedAt;
+
+    // 엔터티가 생성될 때 자동으로 날짜를 설정함
+    @PrePersist
+    public void onPrePersist() {
+        this.appliedAt = LocalDateTime.now();
+    }
+
+    // private 생성자로 외부에서 new 키워드를 통한 직접 생성을 제한함
+    private StudyApplication(StudyRoom studyRoom, AccountProfile applicant, String message) {
+        this.studyRoom = studyRoom;
+        this.applicant = applicant;
+        this.message = message;
+        this.status = ApplicationStatus.PENDING;
+    }
+
+    // 정적 팩토리 메소드
+    public static StudyApplication create(StudyRoom studyRoom, AccountProfile applicant, String message) {
+        return new StudyApplication(studyRoom, applicant, message);
+    }
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/repository/StudyApplicationRepository.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/repository/StudyApplicationRepository.java
@@ -1,0 +1,12 @@
+package com.wowraid.jobspoon.studyApplication.repository;
+
+import com.wowraid.jobspoon.accountProfile.entity.AccountProfile;
+import com.wowraid.jobspoon.studyApplication.entity.StudyApplication;
+import com.wowraid.jobspoon.studyroom.entity.StudyRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyApplicationRepository extends JpaRepository<StudyApplication, Long> {
+
+    // 특정 스터디와 지원자로 지원 내역이 존재하는지 확인(중복지원 방지용)
+    boolean existsByStudyRoomAndApplicant(StudyRoom studyRoom, AccountProfile applicant);
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/service/StudyApplicationService.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/service/StudyApplicationService.java
@@ -1,0 +1,8 @@
+package com.wowraid.jobspoon.studyApplication.service;
+
+import com.wowraid.jobspoon.studyApplication.service.request.CreateStudyApplicationRequest;
+import com.wowraid.jobspoon.studyApplication.service.response.CreateStudyApplicationResponse;
+
+public interface StudyApplicationService {
+    CreateStudyApplicationResponse applyToStudy(CreateStudyApplicationRequest request);
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/service/StudyApplicationServiceImpl.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/service/StudyApplicationServiceImpl.java
@@ -1,0 +1,56 @@
+package com.wowraid.jobspoon.studyApplication.service;
+
+import com.wowraid.jobspoon.accountProfile.entity.AccountProfile;
+import com.wowraid.jobspoon.accountProfile.repository.AccountProfileRepository;
+import com.wowraid.jobspoon.studyApplication.entity.StudyApplication;
+import com.wowraid.jobspoon.studyApplication.repository.StudyApplicationRepository;
+import com.wowraid.jobspoon.studyApplication.service.request.CreateStudyApplicationRequest;
+import com.wowraid.jobspoon.studyApplication.service.response.CreateStudyApplicationResponse;
+import com.wowraid.jobspoon.studyroom.entity.StudyRoom;
+import com.wowraid.jobspoon.studyroom.repository.StudyRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StudyApplicationServiceImpl implements StudyApplicationService {
+
+    private final StudyApplicationRepository studyApplicationRepository;
+    private final StudyRoomRepository studyRoomRepository;
+    private final AccountProfileRepository accountProfileRepository;
+
+    @Override
+    public CreateStudyApplicationResponse applyToStudy(CreateStudyApplicationRequest request) {
+        log.info("applyToStudy 서비스 시작. studyRoomId={}, applicantId={}, message='{}'",
+                request.getStudyRoomId(), request.getApplicantId(), request.getMessage());
+
+        AccountProfile applicant = accountProfileRepository.findById(request.getApplicantId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 지원자를 찾을 수 없습니다. ID: " + request.getApplicantId()));
+
+        StudyRoom studyRoom = studyRoomRepository.findById(request.getStudyRoomId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 스터디모임을 찾을 수 없습니다. ID: " + request.getStudyRoomId()));
+
+        if (studyRoom.getHost().getId().equals(applicant.getId())) {
+            throw new IllegalStateException("모임장은 자신의 스터디에 지원할 수 없습니다.");
+        }
+
+        boolean isAlreadyApplied = studyApplicationRepository.existsByStudyRoomAndApplicant(studyRoom, applicant);
+        if (isAlreadyApplied) {
+            throw new IllegalStateException("이미 해당 스터디모임에 지원했습니다.");
+        }
+
+        StudyApplication studyApplication = StudyApplication.create(
+                studyRoom,
+                applicant,
+                request.getMessage()
+        );
+
+        StudyApplication savedApplication = studyApplicationRepository.save(studyApplication);
+
+        return CreateStudyApplicationResponse.from(savedApplication);
+    }
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/service/request/CreateStudyApplicationRequest.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/service/request/CreateStudyApplicationRequest.java
@@ -1,0 +1,12 @@
+package com.wowraid.jobspoon.studyApplication.service.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateStudyApplicationRequest {
+    private final Long studyRoomId;
+    private final Long applicantId;
+    private final String message;
+}

--- a/src/main/java/com/wowraid/jobspoon/studyApplication/service/response/CreateStudyApplicationResponse.java
+++ b/src/main/java/com/wowraid/jobspoon/studyApplication/service/response/CreateStudyApplicationResponse.java
@@ -1,0 +1,24 @@
+package com.wowraid.jobspoon.studyApplication.service.response;
+
+import com.wowraid.jobspoon.studyApplication.entity.ApplicationStatus;
+import com.wowraid.jobspoon.studyApplication.entity.StudyApplication;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateStudyApplicationResponse {
+    private final Long applicationId;
+    private final ApplicationStatus status;
+    private final LocalDateTime appliedAt;
+
+    public static CreateStudyApplicationResponse from(StudyApplication studyApplication) {
+        return new CreateStudyApplicationResponse(
+                studyApplication.getId(),
+                studyApplication.getStatus(),
+                studyApplication.getAppliedAt()
+        );
+    }
+}

--- a/src/main/java/com/wowraid/jobspoon/studyroom/controller/StudyRoomController.java
+++ b/src/main/java/com/wowraid/jobspoon/studyroom/controller/StudyRoomController.java
@@ -1,26 +1,18 @@
 package com.wowraid.jobspoon.studyroom.controller;
 
-import com.wowraid.jobspoon.studyroom.controller.request_Form.CreateStudyRoomRequestForm;
-import com.wowraid.jobspoon.studyroom.controller.request_Form.UpdateStudyRoomRequestForm;
-import com.wowraid.jobspoon.studyroom.controller.request_Form.UpdateStudyRoomStatusRequestForm;
-import com.wowraid.jobspoon.studyroom.controller.response_form.CreateStudyRoomResponseForm;
-import com.wowraid.jobspoon.studyroom.controller.response_form.ListStudyRoomResponseForm;
-import com.wowraid.jobspoon.studyroom.controller.response_form.ReadStudyRoomResponseForm;
-import com.wowraid.jobspoon.studyroom.controller.response_form.UpdateStudyRoomResponseForm;
-import com.wowraid.jobspoon.studyroom.entity.StudyRoom;
+import com.wowraid.jobspoon.redis_cache.RedisCacheService;
+import com.wowraid.jobspoon.studyroom.controller.request_Form.*;
+import com.wowraid.jobspoon.studyroom.controller.response_form.*;
 import com.wowraid.jobspoon.studyroom.service.StudyRoomService;
 import com.wowraid.jobspoon.studyroom.service.request.ListStudyRoomRequest;
-import com.wowraid.jobspoon.studyroom.service.response.CreateStudyRoomResponse;
-import com.wowraid.jobspoon.studyroom.service.response.ListStudyRoomResponse;
-import com.wowraid.jobspoon.studyroom.service.response.ReadStudyRoomResponse;
-import com.wowraid.jobspoon.studyroom.service.response.UpdateStudyRoomResponse;
+import com.wowraid.jobspoon.studyroom.service.response.*;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/study-rooms")
@@ -28,70 +20,72 @@ import java.net.URI;
 public class StudyRoomController {
 
     private final StudyRoomService studyRoomService;
+    private final RedisCacheService redisCacheService;
 
     @PostMapping
     public ResponseEntity<CreateStudyRoomResponseForm> createStudyRoom(
+            @RequestHeader("Authorization") String authorizationHeader,
             @RequestBody CreateStudyRoomRequestForm requestForm) {
 
-        Long hostId = 1L;
+        String token = authorizationHeader.substring(7);
+        Long hostId = redisCacheService.getValueByKey(token, Long.class);
 
-        // 👇 Service는 이제 CreateStudyRoomResponse를 반환합니다.
-        CreateStudyRoomResponse serviceResponse = studyRoomService.createStudyRoom(requestForm, hostId);
-
-        // 👇 Service 응답을 Controller Form으로 변환합니다.
-        CreateStudyRoomResponseForm responseForm = CreateStudyRoomResponseForm.from(serviceResponse);
-
-        // 👇 생성된 데이터를 Body에 담아 201 Created 응답을 보냅니다.
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseForm);
+        CreateStudyRoomResponse serviceResponse = studyRoomService.createStudyRoom(requestForm.toServiceRequest(hostId));
+        return ResponseEntity.status(HttpStatus.CREATED).body(CreateStudyRoomResponseForm.from(serviceResponse));
     }
 
     @GetMapping
     public ResponseEntity<ListStudyRoomResponseForm> getAllStudyRooms(
             @RequestParam(required = false) Long lastStudyId,
             @RequestParam int size) {
-
         ListStudyRoomRequest serviceRequest = new ListStudyRoomRequest(lastStudyId, size);
         ListStudyRoomResponse serviceResponse = studyRoomService.findAllStudyRooms(serviceRequest);
-        ListStudyRoomResponseForm responseForm = ListStudyRoomResponseForm.from(serviceResponse);
-
-        return ResponseEntity.ok(responseForm);
+        return ResponseEntity.ok(ListStudyRoomResponseForm.from(serviceResponse));
     }
 
     @GetMapping("/{studyRoomId}")
     public ResponseEntity<ReadStudyRoomResponseForm> readStudyRoom(@PathVariable Long studyRoomId) {
-
         ReadStudyRoomResponse serviceResponse = studyRoomService.readStudyRoom(studyRoomId);
         return ResponseEntity.ok(ReadStudyRoomResponseForm.from(serviceResponse));
     }
 
     @PutMapping("/{studyRoomId}")
-    public ResponseEntity<UpdateStudyRoomResponseForm> updateStudyRoom (
+    public ResponseEntity<UpdateStudyRoomResponseForm> updateStudyRoom(
             @PathVariable Long studyRoomId,
+            @RequestHeader("Authorization") String authorizationHeader,
             @RequestBody UpdateStudyRoomRequestForm requestForm) {
 
-        // Controller는 RequestForm을 Service용 Request 객체로 변환
-        UpdateStudyRoomResponse serviceResponse = studyRoomService.updateStudyRoom(studyRoomId, requestForm.toServiceRequest());
+        String token = authorizationHeader.substring(7);
+        Long currentUserId = redisCacheService.getValueByKey(token, Long.class);
 
-        // Service에서 받은 Response를 Controller용 Form 객체로 변환
-        UpdateStudyRoomResponseForm responseForm = UpdateStudyRoomResponseForm.from(serviceResponse);
-
-        return ResponseEntity.ok(responseForm);
+        UpdateStudyRoomResponse serviceResponse = studyRoomService.updateStudyRoom(
+                studyRoomId, currentUserId, requestForm.toServiceRequest()
+        );
+        return ResponseEntity.ok(UpdateStudyRoomResponseForm.from(serviceResponse));
     }
 
     @PatchMapping("/{studyRoomId}/status")
     public ResponseEntity<Void> updateStudyRoomStatus(
             @PathVariable Long studyRoomId,
+            @RequestHeader("Authorization") String authorizationHeader,
             @RequestBody UpdateStudyRoomStatusRequestForm requestForm) {
-        studyRoomService.updateStudyRoomStatus(studyRoomId, requestForm.toServiceRequest());
+
+        String token = authorizationHeader.substring(7);
+        Long currentUserId = redisCacheService.getValueByKey(token, Long.class);
+
+        studyRoomService.updateStudyRoomStatus(studyRoomId, currentUserId, requestForm.toServiceRequest());
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{studyRoomId}")
-    public ResponseEntity<Void> deleteStudyRoom(@PathVariable Long studyRoomId) {
-        Long currentUserId = 1L;        // 추후에 실제 로그인 Id를 가져와야함.
+    public ResponseEntity<Void> deleteStudyRoom(
+            @PathVariable Long studyRoomId,
+            @RequestHeader("Authorization") String authorizationHeader) {
+
+        String token = authorizationHeader.substring(7);
+        Long currentUserId = redisCacheService.getValueByKey(token, Long.class);
 
         studyRoomService.deleteStudyRoom(studyRoomId, currentUserId);
-
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/wowraid/jobspoon/studyroom/controller/response_form/CreateStudyRoomResponseForm.java
+++ b/src/main/java/com/wowraid/jobspoon/studyroom/controller/response_form/CreateStudyRoomResponseForm.java
@@ -17,6 +17,7 @@ public class CreateStudyRoomResponseForm {
     private final Integer maxMembers;
     private final String status;
     private final String location;
+    private final String studyLevel;
     private final List<String> recruitingRoles;
     private final List<String> skillStack;
     private final LocalDateTime createdAt;
@@ -29,6 +30,7 @@ public class CreateStudyRoomResponseForm {
                 response.getMaxMembers(),
                 response.getStatus(),
                 response.getLocation(),
+                response.getStudyLevel(),
                 response.getRecruitingRoles(),
                 response.getSkillStack(),
                 response.getCreatedAt()

--- a/src/main/java/com/wowraid/jobspoon/studyroom/service/StudyRoomService.java
+++ b/src/main/java/com/wowraid/jobspoon/studyroom/service/StudyRoomService.java
@@ -1,6 +1,7 @@
 package com.wowraid.jobspoon.studyroom.service;
 
 import com.wowraid.jobspoon.studyroom.controller.request_Form.CreateStudyRoomRequestForm;
+import com.wowraid.jobspoon.studyroom.service.request.CreateStudyRoomRequest;
 import com.wowraid.jobspoon.studyroom.service.request.ListStudyRoomRequest;
 import com.wowraid.jobspoon.studyroom.service.request.UpdateStudyRoomRequest;
 import com.wowraid.jobspoon.studyroom.service.request.UpdateStudyRoomStatusRequest;
@@ -9,21 +10,11 @@ import com.wowraid.jobspoon.studyroom.service.response.ListStudyRoomResponse;
 import com.wowraid.jobspoon.studyroom.service.response.ReadStudyRoomResponse;
 import com.wowraid.jobspoon.studyroom.service.response.UpdateStudyRoomResponse;
 
-
 public interface StudyRoomService {
-    // Service가 Controller의 Form을 직접 받도록 하고, 생성된 Entity를 반환
-    CreateStudyRoomResponse createStudyRoom(CreateStudyRoomRequestForm requestForm, Long hostId);
-
-    // 수정 매서드 시그니처 추가
-    UpdateStudyRoomResponse updateStudyRoom(Long studyRoomId, UpdateStudyRoomRequest request);
-
-    // status 수정 전용 매서드 시그니처
-    void updateStudyRoomStatus(Long studyRoomId, UpdateStudyRoomStatusRequest request);
-
+    CreateStudyRoomResponse createStudyRoom(CreateStudyRoomRequest request);
     ReadStudyRoomResponse readStudyRoom(Long studyRoomId);
-
-    // 조회 매서드 시그니처 추가
     ListStudyRoomResponse findAllStudyRooms(ListStudyRoomRequest request);
-
-    void deleteStudyRoom(Long studyRoomId, Long hostId);
+    UpdateStudyRoomResponse updateStudyRoom(Long studyRoomId, Long currentUserId, UpdateStudyRoomRequest request);
+    void updateStudyRoomStatus(Long studyRoomId, Long currentUserId, UpdateStudyRoomStatusRequest request);
+    void deleteStudyRoom(Long studyRoomId, Long currentUserId);
 }

--- a/src/main/java/com/wowraid/jobspoon/studyroom/service/StudyRoomServiceImpl.java
+++ b/src/main/java/com/wowraid/jobspoon/studyroom/service/StudyRoomServiceImpl.java
@@ -1,34 +1,22 @@
 package com.wowraid.jobspoon.studyroom.service;
 
-import com.wowraid.jobspoon.account.entity.Account;
-import com.wowraid.jobspoon.account.repository.AccountRepository;
 import com.wowraid.jobspoon.accountProfile.entity.AccountProfile;
 import com.wowraid.jobspoon.accountProfile.repository.AccountProfileRepository;
-import com.wowraid.jobspoon.studyroom.controller.request_Form.CreateStudyRoomRequestForm;
 import com.wowraid.jobspoon.studyroom.entity.*;
 import com.wowraid.jobspoon.studyroom.repository.StudyMemberRepository;
 import com.wowraid.jobspoon.studyroom.repository.StudyRoomRepository;
-import com.wowraid.jobspoon.studyroom.service.request.ListStudyRoomRequest;
-import com.wowraid.jobspoon.studyroom.service.request.UpdateStudyRoomRequest;
-import com.wowraid.jobspoon.studyroom.service.request.UpdateStudyRoomStatusRequest;
-import com.wowraid.jobspoon.studyroom.service.response.CreateStudyRoomResponse;
-import com.wowraid.jobspoon.studyroom.service.response.ListStudyRoomResponse;
-import com.wowraid.jobspoon.studyroom.service.response.ReadStudyRoomResponse;
-import com.wowraid.jobspoon.studyroom.service.response.UpdateStudyRoomResponse;
+import com.wowraid.jobspoon.studyroom.service.StudyRoomService;
+import com.wowraid.jobspoon.studyroom.service.request.*;
+import com.wowraid.jobspoon.studyroom.service.response.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -40,102 +28,66 @@ public class StudyRoomServiceImpl implements StudyRoomService {
 
     @Override
     @Transactional
-    public CreateStudyRoomResponse createStudyRoom(CreateStudyRoomRequestForm requestForm, Long hostId) {
-        AccountProfile host = accountProfileRepository.findById(hostId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    public CreateStudyRoomResponse createStudyRoom(CreateStudyRoomRequest request) {
+            AccountProfile host = accountProfileRepository.findById(request.getHostId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 프로필입니다."));
 
-        StudyRoom studyRoom = StudyRoom.create(
-                host,
-                requestForm.getTitle(),
-                requestForm.getDescription(),
-                requestForm.getMaxMembers(),
-                StudyLocation.valueOf(requestForm.getLocation().toUpperCase()),
-                StudyLevel.valueOf(requestForm.getStudyLevel().toUpperCase()),
-                requestForm.getRecruitingRoles(),
-                requestForm.getSkillStack()
-        );
-        StudyRoom savedStudyRoom = studyRoomRepository.save(studyRoom);
+            StudyRoom studyRoom = StudyRoom.create(
+                    host,
+                    request.getTitle(),
+                    request.getDescription(),
+                    request.getMaxMembers(),
+                    request.getLocation(),
+                    request.getStudyLevel(),
+                    request.getRecruitingRoles(),
+                    request.getSkillStack()
+            );
+            StudyRoom savedStudyRoom = studyRoomRepository.save(studyRoom);
 
-        StudyMember studyHost = StudyMember.create(savedStudyRoom, host, StudyRole.LEADER);
-        studyMemberRepository.save(studyHost);
-
-        return CreateStudyRoomResponse.from(savedStudyRoom);
-    }
-
-    public ListStudyRoomResponse findAllStudyRooms(ListStudyRoomRequest request) {
-        Pageable pageable = PageRequest.of(0, request.getSize(), Sort.by("id").descending());
-
-        Slice<StudyRoom> slice = (request.getLastStudyId() == null)
-                ? studyRoomRepository.findAllByOrderByIdDesc(pageable)
-                : studyRoomRepository.findByIdLessThanOrderByIdDesc(request.getLastStudyId(), pageable);
-
-        // 👉 여기서 Entity → DTO(Map) 변환을 끝냄
-        List<Map<String, Object>> studyRoomList = slice.getContent().stream()
-                .map(room -> {
-                    Map<String, Object> map = new HashMap<>();
-                    map.put("id", room.getId());
-                    map.put("title", room.getTitle());
-                    map.put("status", room.getStatus().name());
-                    map.put("location", room.getLocation().name());
-                    map.put("studyLevel", room.getStudyLevel().name());
-                    map.put("recruitingRoles", room.getRecruitingRoles());
-                    map.put("skillStack", room.getSkillStack());
-                    map.put("maxMembers", room.getMaxMembers());
-                    return map;
-                })
-                .collect(Collectors.toList());
-
-        return new ListStudyRoomResponse(studyRoomList, slice.hasNext());
-    }
+            StudyMember studyHost = StudyMember.create(savedStudyRoom, host, StudyRole.LEADER);
+            studyMemberRepository.save(studyHost);
+            return CreateStudyRoomResponse.from(savedStudyRoom);
+        }
 
     @Override
     public ReadStudyRoomResponse readStudyRoom(Long studyRoomId) {
+        StudyRoom studyRoom = studyRoomRepository.findByIdWithHost(studyRoomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디룸입니다."));
+        return ReadStudyRoomResponse.from(studyRoom);
+    }
 
-        StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디모임 입니다."));
-        String nickname = studyRoom.getHost().getNickname();
-
-        // 지연 로딩된 데이터 강제 초기화
-        studyRoom.getRecruitingRoles().size();
-        studyRoom.getSkillStack().size();
-
-        return ReadStudyRoomResponse.from(studyRoom, nickname);
+    @Override
+    public ListStudyRoomResponse findAllStudyRooms(ListStudyRoomRequest request) {
+        Pageable pageable = PageRequest.of(0, request.getSize());
+        Slice<StudyRoom> slice = (request.getLastStudyId() == null)
+                ? studyRoomRepository.findAllByOrderByIdDesc(pageable)
+                : studyRoomRepository.findByIdLessThanOrderByIdDesc(request.getLastStudyId(), pageable);
+        return new ListStudyRoomResponse(slice);
     }
 
     @Override
     @Transactional
-    public UpdateStudyRoomResponse updateStudyRoom(Long studyRoomId, UpdateStudyRoomRequest request) {
-        // 👇 findById 대신 findByIdWithHost를 사용합니다.
+    public UpdateStudyRoomResponse updateStudyRoom(Long studyRoomId, Long currentUserId, UpdateStudyRoomRequest request) {
         StudyRoom studyRoom = studyRoomRepository.findByIdWithHost(studyRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디모임입니다."));
-
-        Long currentUserId = 1L; // TODO: 실제 로그인한 사용자의 ID (AccountProfile ID)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디룸입니다."));
 
         if (!studyRoom.getHost().getId().equals(currentUserId)) {
             throw new IllegalStateException("수정 권한이 없는 사용자입니다.");
         }
 
         studyRoom.update(
-                request.getTitle(),
-                request.getDescription(),
-                request.getMaxMembers(),
-                request.getLocation(),
-                request.getStudyLevel(),
-                request.getRecruitingRoles(),
-                request.getSkillStack()
+                request.getTitle(), request.getDescription(), request.getMaxMembers(),
+                request.getLocation(), request.getStudyLevel(),
+                request.getRecruitingRoles(), request.getSkillStack()
         );
-
         return UpdateStudyRoomResponse.from(studyRoom);
     }
 
     @Override
     @Transactional
-    public void updateStudyRoomStatus(Long studyRoomId, UpdateStudyRoomStatusRequest request) {
-        // 👇 findById 대신 findByIdWithHost를 사용합니다.
+    public void updateStudyRoomStatus(Long studyRoomId, Long currentUserId, UpdateStudyRoomStatusRequest request) {
         StudyRoom studyRoom = studyRoomRepository.findByIdWithHost(studyRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디모임입니다."));
-
-        Long currentUserId = 1L; // TODO: 실제 로그인한 사용자의 ID (AccountProfile ID)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디룸입니다."));
 
         if (!studyRoom.getHost().getId().equals(currentUserId)) {
             throw new IllegalStateException("수정 권한이 없는 사용자입니다.");
@@ -145,12 +97,11 @@ public class StudyRoomServiceImpl implements StudyRoomService {
 
     @Override
     @Transactional
-    public void deleteStudyRoom(Long studyRoomId, Long hostId) {
-        StudyRoom studyRoom = studyRoomRepository.findById(studyRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디 모임입니다."));
+    public void deleteStudyRoom(Long studyRoomId, Long currentUserId) {
+        StudyRoom studyRoom = studyRoomRepository.findByIdWithHost(studyRoomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스터디룸입니다."));
 
-        // 권한 검사 (로그인한 사용자가 모임장인지)
-        if (!studyRoom.getHost().getId().equals(hostId)) {
+        if (!studyRoom.getHost().getId().equals(currentUserId)) {
             throw new IllegalStateException("삭제 권한이 없는 사용자입니다.");
         }
         studyRoomRepository.delete(studyRoom);

--- a/src/main/java/com/wowraid/jobspoon/studyroom/service/request/CreateStudyRoomRequest.java
+++ b/src/main/java/com/wowraid/jobspoon/studyroom/service/request/CreateStudyRoomRequest.java
@@ -15,7 +15,7 @@ public class CreateStudyRoomRequest {
     private final String description;
     private final Integer maxMembers;
     private final StudyLocation location;
-    private final StudyLevel level;
+    private final StudyLevel studyLevel;
     private final List<String> recruitingRoles;
     private final List<String> skillStack;
 }

--- a/src/main/java/com/wowraid/jobspoon/studyroom/service/response/ReadStudyRoomResponse.java
+++ b/src/main/java/com/wowraid/jobspoon/studyroom/service/response/ReadStudyRoomResponse.java
@@ -22,7 +22,7 @@ public class ReadStudyRoomResponse {
     private final LocalDateTime createdAt;
     private final Long hostId;
 
-    public static ReadStudyRoomResponse from(StudyRoom studyRoom, String hostNickname) {
+    public static ReadStudyRoomResponse from(StudyRoom studyRoom) {
         return new ReadStudyRoomResponse(
                 studyRoom.getId(),
                 studyRoom.getTitle(),

--- a/src/test/java/com/wowraid/jobspoon/studyApplication/controller/StudyApplicationControllerTest.java
+++ b/src/test/java/com/wowraid/jobspoon/studyApplication/controller/StudyApplicationControllerTest.java
@@ -1,0 +1,97 @@
+package com.wowraid.jobspoon.studyApplication.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wowraid.jobspoon.redis_cache.RedisCacheService;
+import com.wowraid.jobspoon.studyApplication.controller.request_form.CreateStudyApplicationRequestForm;
+import com.wowraid.jobspoon.studyApplication.entity.ApplicationStatus;
+import com.wowraid.jobspoon.studyApplication.service.StudyApplicationService;
+import com.wowraid.jobspoon.studyApplication.service.request.CreateStudyApplicationRequest;
+import com.wowraid.jobspoon.studyApplication.service.response.CreateStudyApplicationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(StudyApplicationController.class)
+class StudyApplicationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private StudyApplicationService studyApplicationService;
+
+    @MockBean
+    private RedisCacheService redisCacheService;
+
+    private final String FAKE_TOKEN = "Bearer fake-token-123";
+    private final Long FAKE_APPLICANT_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        // Redis에서 정상적으로 사용자 ID를 찾아오는 상황을 Mocking
+        when(redisCacheService.getValueByKey(eq("fake-token-123"), eq(Long.class)))
+                .thenReturn(FAKE_APPLICANT_ID);
+    }
+
+    @Test
+    @DisplayName("스터디 지원 API 테스트 - 성공")
+    void applyToStudy_success() throws Exception {
+        // given
+        CreateStudyApplicationRequestForm requestForm = new CreateStudyApplicationRequestForm(14L, "열심히 하겠습니다.");
+
+        CreateStudyApplicationResponse serviceResponse = new CreateStudyApplicationResponse(
+                1L, ApplicationStatus.PENDING, LocalDateTime.now()
+        );
+
+        // Service가 성공적으로 응답을 반환하는 상황을 Mocking
+        when(studyApplicationService.applyToStudy(any(CreateStudyApplicationRequest.class)))
+                .thenReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/study-applications")
+                        .header("Authorization", FAKE_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestForm)))
+                .andExpect(status().isCreated()) // 201 Created 응답 확인
+                .andExpect(jsonPath("$.applicationId").value(1L))
+                .andExpect(jsonPath("$.status").value("PENDING"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("스터디 지원 API 테스트 - 실패 (유효하지 않은 토큰)")
+    void applyToStudy_fail_invalidToken() throws Exception {
+        // given
+        CreateStudyApplicationRequestForm requestForm = new CreateStudyApplicationRequestForm(14L, "열심히 하겠습니다.");
+
+        // Redis에서 null을 반환하는(토큰이 없는) 상황을 Mocking
+        when(redisCacheService.getValueByKey(eq("invalid-token"), eq(Long.class)))
+                .thenReturn(null);
+
+        // when & then
+        mockMvc.perform(post("/api/study-applications")
+                        .header("Authorization", "Bearer invalid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestForm)))
+                .andExpect(status().isUnauthorized()) // 401 Unauthorized 응답 확인
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/wowraid/jobspoon/studyApplication/service/StudyApplicationServiceImplTest.java
+++ b/src/test/java/com/wowraid/jobspoon/studyApplication/service/StudyApplicationServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.wowraid.jobspoon.studyApplication.service;
+
+import com.wowraid.jobspoon.accountProfile.entity.AccountProfile;
+import com.wowraid.jobspoon.accountProfile.repository.AccountProfileRepository;
+import com.wowraid.jobspoon.studyApplication.entity.StudyApplication;
+import com.wowraid.jobspoon.studyApplication.repository.StudyApplicationRepository;
+import com.wowraid.jobspoon.studyApplication.service.request.CreateStudyApplicationRequest;
+import com.wowraid.jobspoon.studyApplication.service.response.CreateStudyApplicationResponse;
+import com.wowraid.jobspoon.studyroom.entity.StudyRoom;
+import com.wowraid.jobspoon.studyroom.repository.StudyRoomRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StudyApplicationServiceImplTest {
+
+    @InjectMocks
+    private StudyApplicationServiceImpl studyApplicationService;
+
+    @Mock
+    private StudyApplicationRepository studyApplicationRepository;
+    @Mock
+    private StudyRoomRepository studyRoomRepository;
+    @Mock
+    private AccountProfileRepository accountProfileRepository;
+
+    @Test
+    @DisplayName("스터디 지원 서비스 테스트 - 성공")
+    void applyToStudy_success() {
+        // given
+        final Long applicantId = 1L;
+        final Long hostId = 2L; // 지원자와 다른 ID
+        final Long studyRoomId = 14L;
+
+        CreateStudyApplicationRequest request = new CreateStudyApplicationRequest(studyRoomId, applicantId, "지원합니다.");
+
+        AccountProfile fakeApplicant = createFakeProfile(applicantId);
+        AccountProfile fakeHost = createFakeProfile(hostId);
+        StudyRoom fakeStudyRoom = createFakeStudyRoom(studyRoomId, fakeHost);
+
+        // Repository 동작 Mocking
+        when(accountProfileRepository.findById(applicantId)).thenReturn(Optional.of(fakeApplicant));
+        when(studyRoomRepository.findById(studyRoomId)).thenReturn(Optional.of(fakeStudyRoom));
+        when(studyApplicationRepository.existsByStudyRoomAndApplicant(fakeStudyRoom, fakeApplicant)).thenReturn(false);
+        when(studyApplicationRepository.save(any(StudyApplication.class))).thenAnswer(invocation -> {
+            StudyApplication app = invocation.getArgument(0);
+            ReflectionTestUtils.setField(app, "id", 1L);
+            return app;
+        });
+
+        // when
+        CreateStudyApplicationResponse response = studyApplicationService.applyToStudy(request);
+
+        // then
+        assertThat(response.getApplicationId()).isEqualTo(1L);
+        verify(studyApplicationRepository).save(any(StudyApplication.class));
+    }
+
+    @Test
+    @DisplayName("스터디 지원 서비스 테스트 - 실패 (스터디장이 지원)")
+    void applyToStudy_fail_hostIsApplicant() {
+        // given
+        final Long applicantId = 1L;
+        final Long hostId = 1L; // 지원자와 같은 ID
+        final Long studyRoomId = 14L;
+
+        CreateStudyApplicationRequest request = new CreateStudyApplicationRequest(studyRoomId, applicantId, "지원합니다.");
+
+        AccountProfile fakeApplicant = createFakeProfile(applicantId);
+        StudyRoom fakeStudyRoom = createFakeStudyRoom(studyRoomId, fakeApplicant); // host가 지원자와 동일
+
+        when(accountProfileRepository.findById(applicantId)).thenReturn(Optional.of(fakeApplicant));
+        when(studyRoomRepository.findById(studyRoomId)).thenReturn(Optional.of(fakeStudyRoom));
+
+        // when & then
+        assertThatThrownBy(() -> studyApplicationService.applyToStudy(request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("모임장은 자신의 스터디에 지원할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("스터디 지원 서비스 테스트 - 실패 (중복 지원)")
+    void applyToStudy_fail_alreadyApplied() {
+        // given
+        final Long applicantId = 1L;
+        final Long hostId = 2L;
+        final Long studyRoomId = 14L;
+
+        CreateStudyApplicationRequest request = new CreateStudyApplicationRequest(studyRoomId, applicantId, "지원합니다.");
+
+        AccountProfile fakeApplicant = createFakeProfile(applicantId);
+        AccountProfile fakeHost = createFakeProfile(hostId);
+        StudyRoom fakeStudyRoom = createFakeStudyRoom(studyRoomId, fakeHost);
+
+        when(accountProfileRepository.findById(applicantId)).thenReturn(Optional.of(fakeApplicant));
+        when(studyRoomRepository.findById(studyRoomId)).thenReturn(Optional.of(fakeStudyRoom));
+        // 이미 지원한 상황을 Mocking
+        when(studyApplicationRepository.existsByStudyRoomAndApplicant(fakeStudyRoom, fakeApplicant)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> studyApplicationService.applyToStudy(request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 해당 스터디모임에 지원했습니다.");
+    }
+
+    // 테스트용 가짜 객체 생성 헬퍼 메소드
+    private AccountProfile createFakeProfile(Long id) {
+        AccountProfile profile = new AccountProfile();
+        ReflectionTestUtils.setField(profile, "id", id);
+        return profile;
+    }
+
+    private StudyRoom createFakeStudyRoom(Long id, AccountProfile host) {
+        StudyRoom studyRoom = StudyRoom.create(host, "테스트 스터디", "설명", 5, null, null, null, null);
+        ReflectionTestUtils.setField(studyRoom, "id", id);
+        return studyRoom;
+    }
+}


### PR DESCRIPTION
1. chore
- 기존 사용자계정 목업데이터 삭제
- 임시 Redis 토큰 기반의 실제 계정 연동 완료