### PR TITLE
feat: [정은선] 사용자는 내 출석률, 문제 풀이 수, 면접 횟수 등 활동 지표를 대시보드에서 확인할 수 있다 [JSAB-22]

### DIFF
--- a/src/main/java/com/wowraid/jobspoon/quiz/repository/UserQuizSessionRepository.java
+++ b/src/main/java/com/wowraid/jobspoon/quiz/repository/UserQuizSessionRepository.java
@@ -1,0 +1,24 @@
+package com.wowraid.jobspoon.quiz.repository;
+
+/*
+user_dashboard에서 사용 예정
+ */
+
+import com.wowraid.jobspoon.account.entity.Account;
+import com.wowraid.jobspoon.quiz.entity.UserQuizSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+
+public interface UserQuizSessionRepository extends JpaRepository<UserQuizSession, Long> {
+    long countByAccountId(Long accountId);
+
+    @Query("SELECT COUNT(u) FROM UserQuizSession u " +
+            "WHERE u.account.id = :accountId " +
+            "AND u.startedAt BETWEEN :start AND :end")
+    long countMonthlyByAccountId(@Param("accountId") Long accountId,
+                                 @Param("start") LocalDateTime start,
+                                 @Param("end") LocalDateTime end);
+}

--- a/src/main/java/com/wowraid/jobspoon/user_dashboard/controller/UserDashboardController.java
+++ b/src/main/java/com/wowraid/jobspoon/user_dashboard/controller/UserDashboardController.java
@@ -2,8 +2,10 @@ package com.wowraid.jobspoon.user_dashboard.controller;
 
 import com.wowraid.jobspoon.user_dashboard.controller.response_form.AttendanceRateResponse;
 import com.wowraid.jobspoon.user_dashboard.controller.response_form.InterviewCompletionResponse;
+import com.wowraid.jobspoon.user_dashboard.controller.response_form.QuizCompletionResponse;
 import com.wowraid.jobspoon.user_dashboard.service.AttendanceService;
 import com.wowraid.jobspoon.user_dashboard.service.InterviewSummaryService;
+import com.wowraid.jobspoon.user_dashboard.service.QuizSummaryService;
 import com.wowraid.jobspoon.user_dashboard.service.TokenAccountService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,7 @@ public class UserDashboardController {
     private final TokenAccountService tokenAccountService;
     private final AttendanceService attendanceService;
     private final InterviewSummaryService interviewSummaryService;
+    private final QuizSummaryService quizSummaryService;
 
     @GetMapping("/attendance/rate")
     public ResponseEntity<AttendanceRateResponse> getRate(@RequestHeader("Authorization") String userToken){
@@ -34,6 +37,17 @@ public class UserDashboardController {
     public ResponseEntity<InterviewCompletionResponse> getInterviewCompletion(@RequestHeader("Authorization") String userToken){
         Long accountId = tokenAccountService.resolveAccountId(userToken);
         InterviewCompletionResponse response = interviewSummaryService.getCompletionStatus(accountId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("quiz/completion")
+    public ResponseEntity<QuizCompletionResponse> getQuizCompletion(@RequestHeader("Authorization") String userToken){
+        Long accountId = tokenAccountService.resolveAccountId(userToken);
+        QuizCompletionResponse response = new QuizCompletionResponse(
+                quizSummaryService.getTotalCount(accountId),
+                quizSummaryService.getMonthlyCount(accountId)
+        );
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/wowraid/jobspoon/user_dashboard/controller/response_form/QuizCompletionResponse.java
+++ b/src/main/java/com/wowraid/jobspoon/user_dashboard/controller/response_form/QuizCompletionResponse.java
@@ -1,0 +1,11 @@
+package com.wowraid.jobspoon.user_dashboard.controller.response_form;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuizCompletionResponse {
+    private long quizTotalCount;
+    private long quizMonthlyCount;
+}

--- a/src/main/java/com/wowraid/jobspoon/user_dashboard/repository/InterviewSummaryRepository.java
+++ b/src/main/java/com/wowraid/jobspoon/user_dashboard/repository/InterviewSummaryRepository.java
@@ -10,5 +10,4 @@ public interface InterviewSummaryRepository extends JpaRepository<InterviewSumma
     long countByAccountIdAndStatus(Long accountId, InterviewStatus status);
     long countByAccountIdAndStatusAndCreatedAtBetween(
             Long accountId, InterviewStatus status, LocalDateTime start, LocalDateTime end);
-
 }

--- a/src/main/java/com/wowraid/jobspoon/user_dashboard/service/InterviewSummaryServiceImpl.java
+++ b/src/main/java/com/wowraid/jobspoon/user_dashboard/service/InterviewSummaryServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor
@@ -16,15 +17,17 @@ public class InterviewSummaryServiceImpl implements InterviewSummaryService {
 
     private final InterviewSummaryRepository interviewSummaryRepository;
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     /** 모의면접 완료 횟수 (누적 + 이번 달) **/
     @Override
     @Transactional(readOnly = true)
     public InterviewCompletionResponse getCompletionStatus(Long accountId){
 
         // 이번 달(1일 ~ 말일)
-        YearMonth yearMonth = YearMonth.now();
-        LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
-        LocalDateTime end = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+        YearMonth yearMonth = YearMonth.now(KST);
+        LocalDateTime start = yearMonth.atDay(1).atStartOfDay(KST).toLocalDateTime();
+        LocalDateTime end = yearMonth.atEndOfMonth().atTime(23, 59, 59).atZone(KST).toLocalDateTime();
 
         long totalCompleted = interviewSummaryRepository
                 .countByAccountIdAndStatus(accountId, InterviewStatus.COMPLETED);

--- a/src/main/java/com/wowraid/jobspoon/user_dashboard/service/QuizSummaryService.java
+++ b/src/main/java/com/wowraid/jobspoon/user_dashboard/service/QuizSummaryService.java
@@ -1,0 +1,6 @@
+package com.wowraid.jobspoon.user_dashboard.service;
+
+public interface QuizSummaryService {
+    long getTotalCount(Long accountId);
+    long getMonthlyCount(Long accountId);
+}

--- a/src/main/java/com/wowraid/jobspoon/user_dashboard/service/QuizSummaryServiceImpl.java
+++ b/src/main/java/com/wowraid/jobspoon/user_dashboard/service/QuizSummaryServiceImpl.java
@@ -1,0 +1,38 @@
+package com.wowraid.jobspoon.user_dashboard.service;
+
+import com.wowraid.jobspoon.quiz.repository.UserQuizSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class QuizSummaryServiceImpl implements QuizSummaryService {
+
+    private final UserQuizSessionRepository userQuizSessionRepository;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    /** 총 문제풀이 횟수 */
+    @Override
+    @Transactional(readOnly = true)
+    public long getTotalCount(Long accountId) {
+        return userQuizSessionRepository.countByAccountId(accountId);
+    }
+
+    /** 이번 달 문제풀이 횟수 */
+    @Override
+    @Transactional(readOnly = true)
+    public long getMonthlyCount(Long accountId) {
+
+        YearMonth yearMonth = YearMonth.now(KST);
+        LocalDateTime start = yearMonth.atDay(1).atStartOfDay(KST).toLocalDateTime();
+        LocalDateTime end = yearMonth.atEndOfMonth().atTime(23, 59, 59).atZone(KST).toLocalDateTime();
+
+        return userQuizSessionRepository.countMonthlyByAccountId(accountId, start, end);
+    }
+}


### PR DESCRIPTION
- UserQuizSessionRepository에 accountId 기반 count 쿼리 추가
- QuizSummaryService/Impl 구현 (총 횟수, 월별 횟수 조회)
- QuizCompletionResponse DTO 생성
- UserDashboardController에 /user-dashboard/quiz/completion 엔드포인트 추가
- quiz_set, user_quiz_session 더미 데이터로 검증 완료